### PR TITLE
Revert "Add dumb-init to shutdown a container gracefully"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ end
 Vagrant.configure(2) do |config|
   config.vm.define "wocker"
   config.vm.box = "ailispaw/docker-root"
-  config.vm.box_version = ">= 1.2.8"
+  config.vm.box_version = ">= 1.2.6"
 
   if Vagrant.has_plugin?("vagrant-triggers") then
     config.trigger.after [:up, :resume] do

--- a/provision.sh
+++ b/provision.sh
@@ -35,7 +35,7 @@ chmod +x ${BIN}/wocker
 docker pull wocker/wocker:latest
 ID=$(docker ps -q -a -f name=wocker)
 if [ -z "$ID" ]; then
-  su -c 'wocker run --name wocker "-v /usr/bin/dumb-init:/dumb-init:ro --entrypoint=/dumb-init wocker/wocker sh -c /usr/bin/supervisord"' docker
+  su -c 'wocker run --name wocker' docker
 else
   su -c 'wocker start wocker' docker
 fi


### PR DESCRIPTION
This reverts commit 75e6845691175793e15e978ff1f684dca063ffd2.

Now we don't need dumb-init because of https://github.com/wckr/wocker-dockerfile/commit/80dc35f1498a388b8d1177da6d04b110dc6deb82.
