### PR TITLE
Fix non-ascii characters files disappear in the VirtualBox Shared Folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,8 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = "wocker.dev"
   config.vm.network :private_network, ip: "10.0.23.16"
 
-  config.vm.synced_folder "./data", "/home/bargee/data", create: true
+  config.vm.synced_folder "./data", "/home/bargee/data", create: true,
+    mount_options: ["iocharset=utf8"]
 
   config.vm.provision :shell do |s|
     s.privileged = false


### PR DESCRIPTION
- Fix http://blog.ecoteki.com/webservice/post-2638/
- Related to https://github.com/boot2docker/boot2docker/commit/0de3b8e705a426f19d956241f63f3c2eb5cf1a6c
