### PR TITLE
Enable ssh forwad, for wordmove ssh

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,4 +34,7 @@ Vagrant.configure(2) do |config|
     s.privileged = false
     s.path = 'provision.sh'
   end
+
+  config.ssh.forward_agent = true
+
 end


### PR DESCRIPTION
Wordmove enable connecting remote server by Local SSH key, none password.
Require Forwarding Local SSH key -> BargeOS -> Wocker Container, this PR is setting foward ssh from Local Key to BargeOS.

Enable forwarding BargeOS to Wocker Container, In another pr for [wocker-cli](https://github.com/wckr/wocker-cli).

Required prepare ssh agent for each secret key: ssh-add -K ~/.ssh/id_rsa

ref: https://github.com/wckr/wocker-cli/pull/7
